### PR TITLE
Log execution time for upload endpoint

### DIFF
--- a/lib/routes/upload/index.js
+++ b/lib/routes/upload/index.js
@@ -20,9 +20,17 @@ async function upload(server, options, done) {
       const { id, publicKey, region } = await request.authenticate()
       const { batchTag, payload } = request.body
 
+      const timeStart = Date.now()
+
       const key = await JWK.asKey(publicKey, 'pem')
+
+      const timeVerify = Date.now()
+
       const verify = JWS.createVerify(key)
       const data = await verify.verify(payload)
+
+      const timeParse = Date.now()
+
       const exposures = JSON.parse(data.payload)
 
       for (const { keyData } of exposures) {
@@ -33,10 +41,14 @@ async function upload(server, options, done) {
         }
       }
 
+      const timeBatch = Date.now()
+
       const { rows } = await server.pg.write.query(
         uploadBatchInsert({ id, batchTag })
       )
       const [{ uploadBatchId }] = rows
+
+      const timeExposures = Date.now()
 
       const { rowCount } = await server.pg.write.query(
         exposureInsert({
@@ -46,6 +58,8 @@ async function upload(server, options, done) {
         })
       )
 
+      const timeQueue = Date.now()
+
       if (rowCount && options.aws.batchQueueUrl) {
         const message = {
           QueueUrl: options.aws.batchQueueUrl,
@@ -54,6 +68,20 @@ async function upload(server, options, done) {
 
         await sqs.sendMessage(message).promise()
       }
+
+      const timeEnd = Date.now()
+
+      server.log.trace(
+        {
+          asKey: timeVerify - timeStart,
+          verify: timeParse - timeVerify,
+          parse: timeBatch - timeParse,
+          inserBatch: timeExposures - timeBatch,
+          insertExposures: timeQueue - timeExposures,
+          queue: timeEnd - timeQueue
+        },
+        'perf'
+      )
 
       return {
         batchTag,


### PR DESCRIPTION
This is a quick change to help identify the bottleneck in the upload endpoint.

When tested locally most of the response time seems to be taken by the insert of the exposures. However, initial investigation suggests that on ECS the bottleneck is instead the parsing and verify of the payload, due to the limited cpu resources available.

Using the `test-volume` lambda from https://github.com/nearform/covid-green-interoperability-service/pull/5 on this should confirm that assumption.

I considered using node's perf_hooks, but decided to go with a more simple approach for now.

Should I target the covid green repo with this PR?